### PR TITLE
Fix: "Clear Context" button not appearing on new chat

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -391,6 +391,9 @@ async function sendMessage() {
       addMessageToChat('user', message, new Date().toISOString(), data.user_id, model, conversationIdForRequest);
       addMessageToChat('assistant', data.response, data.time, data.id, data.model, conversationIdForRequest);
 
+      // 发送消息后，确保“清除上下文”按钮可见
+      document.getElementById('clearContextWrapper').style.display = 'block';
+
       try {
         new Audio('https://cdn.jsdelivr.net/npm/sound-effects/sounds/mp3/ting.mp3').play();
       } catch (e) {


### PR DESCRIPTION
The "Clear Context" button was not appearing after sending the first message in a new conversation. It only appeared after a page refresh.

This was because the JavaScript code that adds new messages to the chat did not update the visibility of the button.

The fix is to explicitly set the button's container to `display: block` after a message is successfully sent and added to the DOM. This ensures the button appears immediately as expected.